### PR TITLE
Fix controller sample

### DIFF
--- a/core/sample/controller.html
+++ b/core/sample/controller.html
@@ -28,6 +28,7 @@ function onEnterFrame()
 	for ( var I in list)
 	{
 		var con=list[I].con;
+        con.fetch();
 		var sp =list[I].sp;
 
 		if(con.state.up)


### PR DESCRIPTION
The controller sample did not work. We should either set `con.sync=false` or call `con.fetch()` in every frame. In this fix, `con.fetch()` is used. Now the sample works as expected.