### PR TITLE
Fix issue #9: Added projectile logic to Henry and Rudolf

### DIFF
--- a/LF/global.js
+++ b/LF/global.js
@@ -211,6 +211,7 @@ GC.combo={};
 GC.combo.timeout=10; //how many TUs a combo will still be effective after being fired
 
 GC.unspecified= -842150451; //0xCDCDCDCD, one kind of HEX label
+GC.specialattack_projectiles= [201, 202] //Special attacks that shoot projectiles. Used to apply physics
 
 return G;
 });

--- a/LF/specialattack.js
+++ b/LF/specialattack.js
@@ -33,6 +33,9 @@ var GC=Global.gameplay;
 				if ($.frame.D.sound) {
 					$.match.sound.play($.frame.D.sound);
 				}
+				if ($.frame.N===43) { //on ground
+					$.trans.frame(1000);
+				}
 			break;
 
 			case 'frame_force':
@@ -255,7 +258,9 @@ var GC=Global.gameplay;
 		$.team = config.team;
 		$.match = config.match;
 		$.health.hp = $.proper('hp') || GC.default.health.hp_full;
-		$.mech.mass = 0;
+		if(!GC.specialattack_projectiles.includes(thisID)){
+			$.mech.mass = 0;
+		}
 		$.setup();
 	}
 	specialattack.prototype = new livingobject();


### PR DESCRIPTION
Fix for issue: #9 
Added projectile logic to Henry and Rudolfs special attacks.

- Added global variable array that contains special attacks that are projectiles
- Added logic to special attacks, to skip setting mass to 0, if the id exists in the above array.

This PR has an accompanying PR in LF2_19
https://github.com/Project-F/LF2_19/pull/2

![projectile_falloff](https://user-images.githubusercontent.com/29847637/119653924-3c74d580-be6b-11eb-8196-71a8d96ff7a7.gif)
