### PR TITLE
fixed stepping on character select

### DIFF
--- a/LF/manager.js
+++ b/LF/manager.js
@@ -875,7 +875,7 @@ function Manager(package, buildinfo)
 								players[i].use=true;
 								players[i].type='human';
 								players[i].name=session.player[i]?session.player[i].name:'';
-								players[i].step++;
+								players[i].step < 3 ? players[i].step++ : null;
 								var finished=true;
 								for (var k=0; k<players.length; k++) {
 									finished = finished && (players[k].use? players[k].step===3:true);


### PR DESCRIPTION
Addresses issue #20 
Counter was adding even after the user finished their selection. 
`finished = finished && (players[k].use? players[k].step===3:true);` only works if the counter is 3. 
This resulted in the `finished` boolean never becoming true. 

Added check to prevent steps from being added past 3
