### PR TITLE
Fix firing direction after role

### DIFF
--- a/LF/character.js
+++ b/LF/character.js
@@ -175,6 +175,10 @@ define(['LF/livingobject', 'LF/global', 'core/combodec', 'core/util', 'LF/util']
                 var tag = Global.combo_tag[K]
                 if (tag && $.frame.D[tag]) {
                   if (!$.id_update('generic_combo', K, tag)) {
+                    var dir = Global.combo_dir[K]
+                    if (dir) {
+                      $.switch_dir(dir)
+                    }
                     $.trans.frame($.frame.D[tag], 11)
                     return 1
                   }

--- a/LF/global.js
+++ b/LF/global.js
@@ -57,6 +57,15 @@ define(['LF/util'], function (util) {
     'D>AJ': 'hit_Fj',
     DJA: 'hit_ja'
   }
+  G.combo_dir =
+  {
+    'D<A': 'left',
+    'D>A': 'right',
+    'D<J': 'left',
+    'D>J': 'right',
+    'D<AJ': 'left',
+    'D>AJ': 'right'
+  }
   G.combo_priority =
   { // larger number is higher priority
     up: 0,


### PR DESCRIPTION
- Fixes #10 
- Rather than buffering directional inputs, it seems most natural for the engine to set the direction of the character based on the combo